### PR TITLE
Only upload executable files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,23 @@ jobs:
       - name: Archive packaged app artifact for MacOS
         uses: actions/upload-artifact@v1
         with:
-          name: release/ElectronReact-1.0.0-mac.zip
-          path: ElectronReact-1.0.0-mac.zip
-        if: ${{ contains(matrix.os, 'macos'}}
+          name: wildlife-explorer-mac
+          path: release/ElectronReact-1.0.0-mac.zip
+        if: ${{ contains(matrix.os, 'macos')}}
+
+      - name: Archive packaged app artifact for Windows
+        uses: actions/upload-artifact@v1
+        with:
+          name: wildlife-explorer-windows
+          path: 'release/ElectronReact Setup 1.0.0.exe'
+        if: ${{ contains(matrix.os, 'windows')}}
+
+      - name: Archive packaged app artifact for Debian
+        uses: actions/upload-artifact@v1
+        with:
+          name: wildlife-explorer-deb
+          path: release/electron-react-boilerplate_1.0.0_amd64.deb
+        if: ${{ contains(matrix.os, 'ubuntu')}}
 # Failing beacuse virtual framebuffer not installed
 #          yarn build-e2e
 #          yarn test-e2e


### PR DESCRIPTION
currently we're uploading the whole directory of artifacts. We'll run out of space quickly and it's time consuming to download this huge directory