### PR TITLE
Only run CI on Ubuntu & update OS version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,7 @@ on: push
 
 jobs:
   release:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-10.14, windows-2019, ubuntu-18.04]
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
Only run CI on latest Ubuntu - this should be sufficient, as our CI pretty much just builds and lints our JS.

Running on MacOS is very costly (10x more than on Ubuntu) and we don't need to support it. Windows is also quite expensive (2x more and takes 2x more time).