### PR TITLE
Move detectOverrides() out of ExplorePage

### DIFF
--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -135,6 +135,22 @@ function DataButton({ textTop, textBottom, icon, onClick }: DataButtonProps) {
   );
 }
 
+function detectOverrides(observations: Observation[] | undefined) {
+  if (observations !== undefined) {
+    const override: PredictionOverridesMap = {};
+    observations
+      .filter((observation: Observation) => observation.label !== observation.pred_1)
+      .forEach((observation: Observation) => {
+        override[observation.location] = {
+          label: formatAnimalClassName(observation.label),
+          value: formatAnimalClassName(observation.label)
+        };
+      });
+    return override;
+  }
+  return {};
+}
+
 export default function ExplorePage() {
   const { t } = useTranslation();
   const [filePath, setFilePath] = useState<string>();
@@ -166,25 +182,9 @@ export default function ExplorePage() {
     return false;
   };
 
-  const detectOverrides = (dataObservations: Observation[] | undefined) => {
-    if (dataObservations !== undefined) {
-      const override: PredictionOverridesMap = {};
-      dataObservations
-        .filter((observation: Observation) => observation.label !== observation.pred_1)
-        .forEach((observation: Observation) => {
-          override[observation.location] = {
-            label: formatAnimalClassName(observation.label),
-            value: formatAnimalClassName(observation.label)
-          };
-        });
-      return override;
-    }
-    return {};
-  };
-
   const handleNewDataImport = async () => {
-    const dataObservations = await chooseFile(setFilePath, setObservations);
-    const overrides = await detectOverrides(dataObservations);
+    const newObservations = await chooseFile(setFilePath, setObservations);
+    const overrides = detectOverrides(newObservations);
     setPredictionOverrides(overrides);
     setFilters(initialFilters);
   };


### PR DESCRIPTION
### Description
Move `detectOverrides()` out of `ExplorePage`. Local functions (functions defined in functions) are useful when you need to depend on variables from the outer scope. Otherwise it is better to define it outside - it helps to make the code more modular.

### How to test
Refactoring - behavior should remain unchanged.