### PR TITLE
Use lodash differently to avoid TypeScript issues

### DIFF
--- a/app/utils/computeEvents.ts
+++ b/app/utils/computeEvents.ts
@@ -6,7 +6,7 @@ export default function computeEvents(
   observations: Observation[]
 ): Observation[] {
   let eventId = 0; // Must uniquely identify the event across the whole data set.
-  function handleGroup(group: Observation[]): Observation[] {
+  function mapGroup(group: Observation[]): Observation[] {
     let eventEnd: Date;
     return _(group)
       .sortBy('timestamp')
@@ -22,9 +22,9 @@ export default function computeEvents(
   }
   const result = _(observations)
     .groupBy(o => [o.station, o.label].join()) // Use comma as separator.
-    .mapValues(handleGroup)
-    .flatMap()
+    .values()
+    .map(mapGroup)
+    .flatten()
     .value();
-  // For some reason, TypeScript believes `result` to be `Observation[][]`.
-  return (result as unknown) as Observation[];
+  return result;
 }


### PR DESCRIPTION
With a simple change in lodash usage we can avoid TypeScript  mistaking the result type.