### PR TITLE
Fix filters

### DIFF
--- a/app/assets/translations.json
+++ b/app/assets/translations.json
@@ -104,8 +104,8 @@
           "photoHeader": "{{species}} {{date}}",
           "prediction": "Prediction",
           "probability": "Probability",
+          "override": "Override prediction",
           "overrideTooltip": "You can override the top prediction and export a modified CSV",
-          "overridePlaceholder": "Override prediction",
           "camera": "Camera",
           "file": "File"
         }
@@ -217,8 +217,8 @@
           "photoHeader": "{{species}} {{date}}",
           "prediction": "Prédiction",
           "probability": "Probabilité",
+          "override": "Modifier la prédiction",
           "overrideTooltip": "Vous pouvez modifier la prédiction supérieure et exporter un CSV modifié",
-          "overridePlaceholder": "Modifier la prédiction",
           "camera": "ID de l'appareil photo",
           "file": "Fichier"
         }

--- a/app/components/ObservationsInspector.tsx
+++ b/app/components/ObservationsInspector.tsx
@@ -50,13 +50,13 @@ function ObservationCard(props: ObservationCardProps) {
   );
   const predictionOverrideWidget = (
     <Tooltip content={t('explore.inspect.overrideTooltip')} position={Position.RIGHT}>
-      <div style={{ width: 250 }}>
+      <div style={{ width: 250, marginLeft: 10 }}>
+        <h4 style={{ marginBottom: 5 }}>{t('explore.inspect.override')}</h4>
         <CreatableSelect
           name={predictionOverride}
           value={predictionOverride}
           onChange={handlePredictionOverride}
           isClearable
-          placeholder={t('explore.inspect.overridePlaceholder')}
           options={taxonOptions}
           menuShouldScrollIntoView={false}
         />

--- a/app/components/explorerFilters.tsx
+++ b/app/components/explorerFilters.tsx
@@ -37,7 +37,7 @@ export default function ExplorerFilter(props: Props) {
     });
   };
 
-  const animals = getUniqueSet(observations.map(entry => entry.pred_1)).sort(orderByName);
+  const animals = getUniqueSet(observations.map(entry => entry.label)).sort(orderByName);
   const cameras = getUniqueSet(observations.map(entry => entry.camera)).sort(
     (a, b) => parseInt(a.value, 10) - parseInt(b.value, 10)
   );

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -169,10 +169,10 @@ export default function ExplorePage() {
     if (filters !== undefined) {
       filtered = filtered.filter(
         (entry: Observation) =>
-          filterCondition(entry.pred_1, filters.activeAnimals) &&
+          filterCondition(entry.label, filters.activeAnimals) &&
           filterCondition(entry.camera, filters.activeCameras) &&
           filterCondition(entry.station, filters.activeStations) &&
-          inRange(entry.score_1, filters.certaintyRange)
+          inRange(entry.uncertainty, filters.certaintyRange)
       );
     }
     return { observations: filtered };

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -123,7 +123,7 @@ function missingEvents(observations: Observation[]): number {
 
 function overridesCount(observations: Observation[]): number {
   return observations.reduce((a, b) => a + (b.pred_1 !== b.label ? 1 : 0), 0);
-};
+}
 
 export default function ExplorePage() {
   const { t } = useTranslation();


### PR DESCRIPTION
Closes #205.

### Description
Two fixes for filters and one UI improvement:
1. Use overrides in species and certainty filters (previously the prediction coming from the classifier was always used).
2. Count events in filtered observations (instead of all observations - now all boxes show information with filters applied).
3. Use label instead of placeholder for override dropdown.
