### PR TITLE
Replace analytics library

### DIFF
--- a/app/store/analyticsMiddleware.ts
+++ b/app/store/analyticsMiddleware.ts
@@ -3,7 +3,7 @@ import { createMiddleware, EventsMap } from 'redux-beacon';
 import { trackPageView } from '@redux-beacon/google-analytics';
 import OfflineWeb from '@redux-beacon/offline-web';
 import logger from '@redux-beacon/logger';
-import Analytics from 'electron-ga';
+import Analytics from 'universal-analytics';
 
 const eventsMap: EventsMap = {
   [LOCATION_CHANGE]: trackPageView(action => ({
@@ -15,7 +15,7 @@ const eventsMap: EventsMap = {
 // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dh
 const HOST = 'electron';
 
-const analytics = new Analytics('UA-167871460-1');
+const analytics = Analytics('UA-167871460-1');
 
 type Event = {
   hitType: string;
@@ -27,7 +27,7 @@ function analyticsTarget(events: unknown[]) {
     if (event.hitType === 'pageview') {
       // TODO: Also send `event.timeSaved` if present (happens when events are
       // retrieved from offline storage).
-      analytics.send('pageview', { dh: HOST, dp: event.page });
+      analytics.pageview({ dh: HOST, dp: event.page }).send();
     } else {
       // TODO: Globally disable `no-console` warnings in eslint (this warning
       // probably makes no sense for us) and remove one-line disablers:

--- a/app/store/analyticsMiddleware.ts
+++ b/app/store/analyticsMiddleware.ts
@@ -4,6 +4,7 @@ import { trackPageView } from '@redux-beacon/google-analytics';
 import OfflineWeb from '@redux-beacon/offline-web';
 import logger from '@redux-beacon/logger';
 import Analytics from 'universal-analytics';
+import { machineIdSync } from 'node-machine-id';
 
 const eventsMap: EventsMap = {
   [LOCATION_CHANGE]: trackPageView(action => ({
@@ -15,7 +16,7 @@ const eventsMap: EventsMap = {
 // https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dh
 const HOST = 'electron';
 
-const analytics = Analytics('UA-167871460-1');
+const analytics = Analytics('UA-167871460-1', machineIdSync());
 
 type Event = {
   hitType: string;

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "@types/redux-logger": "^3.0.7",
     "@types/sinon": "^7.5.1",
     "@types/tapable": "^1.0.5",
+    "@types/universal-analytics": "^0.4.5",
     "@types/vfile-message": "^2.0.0",
     "@types/webpack": "^4.41.3",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
@@ -299,7 +300,6 @@
     "date-fns": "^2.28.0",
     "devtron": "^1.4.0",
     "electron-debug": "^3.0.1",
-    "electron-ga": "^1.0.6",
     "electron-log": "^4.0.6",
     "electron-updater": "^4.2.0",
     "history": "^4.10.1",
@@ -317,7 +317,8 @@
     "redux": "^4.0.5",
     "redux-beacon": "^2.1.0",
     "redux-thunk": "^2.3.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "universal-analytics": "^0.5.3"
   },
   "devEngines": {
     "node": ">=7.x",

--- a/package.json
+++ b/package.json
@@ -306,6 +306,7 @@
     "i18next": "^21.8.11",
     "lodash": "^4.17.21",
     "mapbox-gl": "^2.9.1",
+    "node-machine-id": "^1.1.12",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-hot-loader": "^4.12.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/universal-analytics@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@types/universal-analytics/-/universal-analytics-0.4.5.tgz#6a4a88477a70f7ca1ce19caede561ca728149810"
+  integrity sha512-Opb+Un786PS3te24VtJR/QPmX00P/pXaJQtLQYJklQefP4xP0Ic3mPc2z6SDz97OrITzR+RHTBEwjtNRjZ/nLQ==
+
 "@types/vfile-message@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
@@ -5462,6 +5467,13 @@ debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -6036,14 +6048,6 @@ electron-download@^4.1.1:
     rc "^1.2.1"
     semver "^5.4.1"
     sumchecker "^2.0.2"
-
-electron-ga@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/electron-ga/-/electron-ga-1.0.6.tgz#6a1a911902a1d5c75433424d81b8083d5c9350fc"
-  integrity sha512-x+GVARjpa9DdmK9OettGjP6ayTR4OxX60+gRzpmJHAimN/2keOfG/yYvDlhUgZ2qvIFMKhfvjUwrzPSpeTP+oQ==
-  dependencies:
-    node-machine-id "^1.1.9"
-    qs "^6.5.1"
 
 electron-is-accelerator@^0.1.0:
   version "0.1.2"
@@ -10683,11 +10687,6 @@ node-ipc@^9.1.0:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-machine-id@^1.1.9:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/node-machine-id/-/node-machine-id-1.1.12.tgz#37904eee1e59b320bb9c5d6c0a59f3b469cb6267"
-  integrity sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==
-
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -12279,11 +12278,6 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-
-qs@^6.5.1:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
-  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -15241,6 +15235,14 @@ unist-util-visit@^2.0.0:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
+universal-analytics@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.5.3.tgz#ff2d9b850062cdd4a8f652448047982a183c8e96"
+  integrity sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==
+  dependencies:
+    debug "^4.3.1"
+    uuid "^8.0.0"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -15385,6 +15387,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,6 +10687,11 @@ node-ipc@^9.1.0:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
+node-machine-id@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/node-machine-id/-/node-machine-id-1.1.12.tgz#37904eee1e59b320bb9c5d6c0a59f3b469cb6267"
+  integrity sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"


### PR DESCRIPTION
### Description
The `analytics-ga` library seems to be abandoned (last commits 4 years ago) and it depends on an old version of Electron, thus blocking migration to the newest ERB (#241).

The PR replaces it with the popular and well-maintained `universal-analytics`. The `node-machine-id` library is used to generate the client ID ([same method](https://github.com/jaystack/electron-ga/blob/82c5d0db1b9e5437b7d98aa091f328c3f6527951/src/side-effects.ts#L10) as in `analytics-ga`).

I have verified that a launched app can be seen in the "Realtime" section of our [analytics](https://analytics.google.com/analytics/web/#/realtime/rt-overview/a167871460w234298446p219711662/).