### PR TITLE
Explorer Layout Update

### DIFF
--- a/app/components/ExploreHeader.scss
+++ b/app/components/ExploreHeader.scss
@@ -1,7 +1,9 @@
 .container {
   align-items: center;
-  display: flex;
+  display: grid;
+  gap: 15px;
   grid-area: header;
+  grid-template-columns: repeat(2, auto) 1fr;
   justify-content: space-between;
   padding: 10px 0;
 
@@ -42,6 +44,7 @@
 .textOutput {
   align-items: center;
   display: flex;
+  grid-column: 1 / 4;
   flex: 1;
 
   & > h5 {

--- a/app/components/ExploreHeader.scss
+++ b/app/components/ExploreHeader.scss
@@ -3,9 +3,8 @@
   display: grid;
   gap: 15px;
   grid-area: header;
-  grid-template-columns: repeat(2, auto) 1fr;
+  grid-template-columns: 1fr repeat(3, auto);
   justify-content: space-between;
-  padding: 10px 0;
 
   .popover {
     .popoverContent {
@@ -44,7 +43,6 @@
 .textOutput {
   align-items: center;
   display: flex;
-  grid-column: 1 / 4;
   flex: 1;
 
   & > h5 {

--- a/app/components/ExploreHeader.scss
+++ b/app/components/ExploreHeader.scss
@@ -1,6 +1,7 @@
 .container {
   align-items: center;
   display: flex;
+  grid-area: header;
   justify-content: space-between;
   padding: 10px 0;
 

--- a/app/components/ExploreHeader.tsx
+++ b/app/components/ExploreHeader.tsx
@@ -39,7 +39,6 @@ export default function ExploreHeader(props: Props) {
         large
         onClick={onDataImportClick}
         outlined={false}
-        style={{ marginRight: '15px' }}
         text={t('explore.changeFile')}
       />
       <Popover className={s.popover} usePortal={false} autoFocus={false}>
@@ -48,7 +47,6 @@ export default function ExploreHeader(props: Props) {
           intent="primary"
           large
           outlined={false}
-          style={{ marginRight: '15px' }}
           text={t('explore.eventsButtonLabel')}
         />
         <div className={s.popoverContent}>

--- a/app/components/ExplorerFilters.scss
+++ b/app/components/ExplorerFilters.scss
@@ -1,0 +1,18 @@
+@import '../styles/config/variables';
+@import '../styles/config/mixins';
+
+.container {
+  display: grid;
+  gap: 15px;
+  grid-area: filters;
+  grid-template-columns: repeat(4, 1fr);
+  width: 100%;
+
+  .inputGroup {
+    width: 100%;
+  }
+
+  .label {
+    margin-bottom: 5px;
+  }
+}

--- a/app/components/ExplorerFilters.scss
+++ b/app/components/ExplorerFilters.scss
@@ -2,10 +2,11 @@
 @import '../styles/config/mixins';
 
 .container {
+  align-content: start;
   display: grid;
   gap: 15px;
   grid-area: filters;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   width: 100%;
 
   .inputGroup {
@@ -13,6 +14,6 @@
   }
 
   .label {
-    margin-bottom: 5px;
+    margin: 0 0 5px;
   }
 }

--- a/app/components/ExplorerMetrics.scss
+++ b/app/components/ExplorerMetrics.scss
@@ -1,0 +1,11 @@
+@import '../styles/config/variables';
+@import '../styles/config/mixins';
+
+.container {
+  display: grid;
+  gap: 20px;
+  grid-area: metrics;
+  grid-template-columns: repeat(6, 1fr);
+  padding: 15px 0;
+  width: 100%;
+}

--- a/app/components/ExplorerMetrics.scss
+++ b/app/components/ExplorerMetrics.scss
@@ -8,4 +8,37 @@
   grid-area: metrics;
   grid-template-columns: repeat(2, 1fr);
   width: 100%;
+
+  .card {
+    border-radius: $radius-card;
+    box-shadow: $shadow-card;
+    height: 100px;
+    min-width: 100px;
+    padding: 10px;
+    position: relative;
+    text-align: center;
+    width: 100%;
+  }
+
+  .icon {
+    position: absolute;
+    left: 25px;
+    top: 25px;
+  }
+
+  .valueWrapper {
+    margin-left: 50px;
+    margin-top: 10px;
+  }
+
+  .value {
+    font-size: 32px;
+    font-weight: 500;
+    width: 100%;
+  }
+
+  .title {
+    line-height: 15px;
+    margin-top: 10px;
+  }
 }

--- a/app/components/ExplorerMetrics.scss
+++ b/app/components/ExplorerMetrics.scss
@@ -2,10 +2,10 @@
 @import '../styles/config/mixins';
 
 .container {
+  align-content: start;
   display: grid;
   gap: 20px;
   grid-area: metrics;
-  grid-template-columns: repeat(6, 1fr);
-  padding: 15px 0;
+  grid-template-columns: repeat(2, 1fr);
   width: 100%;
 }

--- a/app/components/Map.css
+++ b/app/components/Map.css
@@ -1,3 +1,3 @@
 .mapContainer {
-  height: 600px;
+  height: 100%;
 }

--- a/app/components/explorerFilters.tsx
+++ b/app/components/explorerFilters.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import Select from 'react-select';
 import CertaintyFilter from './CertaintyFilter';
+import styles from './ExplorerFilters.scss';
 
 type Props = {
   observations: Observation[];
@@ -60,30 +61,20 @@ export default function ExplorerFilter(props: Props) {
   };
 
   return (
-    <div style={{ paddingBottom: '10px' }}>
-      <div
-        className="filter-wrapper"
-        style={{
-          display: 'grid',
-          gap: '15px',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          width: '100%'
-        }}
-      >
-        <div>
-          <h4 style={{ marginBottom: '5px' }}>{t('explore.byAnimal')}</h4>
-          <Select onChange={setAnimals} closeMenuOnSelect={false} options={animals} isMulti />
-        </div>
-        <div style={{ width: '100%' }}>
-          <h4 style={{ marginBottom: '5px' }}>{t('explore.byStation')}</h4>
-          <Select onChange={setStations} closeMenuOnSelect={false} options={stations} isMulti />
-        </div>
-        <div style={{ width: '100%' }}>
-          <h4 style={{ marginBottom: '5px' }}>{t('explore.byCamera')}</h4>
-          <Select onChange={setCameras} closeMenuOnSelect={false} options={cameras} isMulti />
-        </div>
-        <CertaintyFilter updateFilters={updateFilters} />
+    <div className={styles.container}>
+      <div className={styles.inputGroup}>
+        <h4 className={styles.label}>{t('explore.byAnimal')}</h4>
+        <Select onChange={setAnimals} closeMenuOnSelect={false} options={animals} isMulti />
       </div>
+      <div className={styles.inputGroup}>
+        <h4 className={styles.label}>{t('explore.byStation')}</h4>
+        <Select onChange={setStations} closeMenuOnSelect={false} options={stations} isMulti />
+      </div>
+      <div className={styles.inputGroup}>
+        <h4 className={styles.label}>{t('explore.byCamera')}</h4>
+        <Select onChange={setCameras} closeMenuOnSelect={false} options={cameras} isMulti />
+      </div>
+      <CertaintyFilter updateFilters={updateFilters} />
     </div>
   );
 }

--- a/app/components/explorerMetrics.tsx
+++ b/app/components/explorerMetrics.tsx
@@ -37,33 +37,14 @@ export default function ExplorerMetrics(props: Props) {
     tooltip: JSX.Element | string = ''
   ) {
     return (
-      <Card
-        elevation={Elevation.TWO}
-        style={{
-          minWidth: '100px',
-          position: 'relative',
-          textAlign: 'center',
-          width: '100%',
-          height: '100px',
-          padding: '10px'
-        }}
-      >
+      <Card className={styles.card} elevation={Elevation.TWO}>
         <Tooltip content={tooltip} position={Position.BOTTOM} disabled={tooltip === ''}>
           <div>
-            <Icon
-              style={{
-                position: 'absolute',
-                left: '25px',
-                top: '25px'
-              }}
-              icon={icon}
-              color={color}
-              iconSize={32}
-            />
-            <div style={{ marginLeft: '50px', marginTop: '10px' }}>
-              <div style={{ fontWeight: 500, fontSize: '32px', width: '100%' }}>{value}</div>
+            <Icon className={styles.icon} icon={icon} color={color} iconSize={32} />
+            <div className={styles.valueWrapper}>
+              <div className={styles.value}>{value}</div>
             </div>
-            <div style={{ lineHeight: '15px', marginTop: '10px' }}>{title}</div>
+            <div className={styles.title}>{title}</div>
           </div>
         </Tooltip>
       </Card>

--- a/app/components/explorerMetrics.tsx
+++ b/app/components/explorerMetrics.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon, IconName, Card, Elevation, Tooltip, Position } from '@blueprintjs/core';
 import AnimalsListTooltipContent from './AnimalsListTooltipContent';
+import styles from './ExplorerMetrics.scss';
 
 type Props = {
   data: Observation[];
@@ -70,16 +71,7 @@ export default function ExplorerMetrics(props: Props) {
   }
 
   return (
-    <div
-      className="metrics-wrapper"
-      style={{
-        display: 'grid',
-        gap: '20px',
-        gridTemplateColumns: 'repeat(6, 1fr)',
-        padding: '15px 0',
-        width: '100%'
-      }}
-    >
+    <div className={styles.container}>
       {metricsCard('camera', '#5c7080', t('explore.imagesCount'), data.length)}
       {metricsCard('inbox-search', '#5c7080', t('explore.animalsCount'), nonEmpty.length)}
       {metricsCard(

--- a/app/containers/ExplorePage.scss
+++ b/app/containers/ExplorePage.scss
@@ -73,7 +73,21 @@
   grid-template-rows: repeat(2, auto) 1fr;
   max-height: calc(100vh - 50px);
   overflow-y: scroll;
-  padding: 30px 30px;
+  padding: 30px;
   position: relative;
   width: 100%;
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    grid-area: map;
+    height: 100%;
+  }
+
+  .cardBody {
+    height: 100%;
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+  }
 }

--- a/app/containers/ExplorePage.scss
+++ b/app/containers/ExplorePage.scss
@@ -59,3 +59,13 @@
     }
   }
 }
+
+.containerLoaded {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 50px);
+  overflow-y: scroll;
+  padding: 30px 30px;
+  position: relative;
+  width: 100%;
+}

--- a/app/containers/ExplorePage.scss
+++ b/app/containers/ExplorePage.scss
@@ -61,8 +61,16 @@
 }
 
 .containerLoaded {
-  display: flex;
+  align-content: start;
+  display: grid;
   flex-direction: column;
+  gap: 40px 30px;
+  grid-template-areas:
+    'header  map'
+    'filters map'
+    'metrics map';
+  grid-template-columns: 450px 1fr;
+  grid-template-rows: repeat(2, auto) 1fr;
   max-height: calc(100vh - 50px);
   overflow-y: scroll;
   padding: 30px 30px;

--- a/app/containers/ExplorePage.scss
+++ b/app/containers/ExplorePage.scss
@@ -66,9 +66,9 @@
   flex-direction: column;
   gap: 40px 30px;
   grid-template-areas:
-    'header  map'
-    'filters map'
-    'metrics map';
+    'header  header'
+    'filters map   '
+    'metrics map   ';
   grid-template-columns: 450px 1fr;
   grid-template-rows: repeat(2, auto) 1fr;
   max-height: calc(100vh - 50px);
@@ -78,10 +78,15 @@
   width: 100%;
 
   .card {
+    box-shadow: $shadow-card;
     display: flex;
     flex-direction: column;
     grid-area: map;
     height: 100%;
+
+    &:hover {
+      box-shadow: $shadow-card;
+    }
   }
 
   .cardBody {

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -226,7 +226,6 @@ export default function ExplorePage() {
         />
         <Divider />
         <ExplorerFilter observations={observations} updateFilters={handleFilters} />
-        <Divider />
         <ExplorerMetrics
           data={filteredObservations}
           rareTargets={RareAnimalsClasses}
@@ -234,7 +233,7 @@ export default function ExplorePage() {
           overridesTotal={overridesCount(filteredObservations)}
           eventsTotal={eventsCount(filteredObservations)}
         />
-        <Card style={{ height: '100%' }} interactive elevation={Elevation.TWO}>
+        <Card style={{ gridArea: 'map', height: '100%' }} interactive elevation={Elevation.TWO}>
           <Callout intent={Intent.PRIMARY}>{t('explore.mapHint')}</Callout>
           <div
             style={{

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -232,20 +232,9 @@ export default function ExplorePage() {
           overridesTotal={overridesCount(filteredObservations)}
           eventsTotal={eventsCount(filteredObservations)}
         />
-        <Card
-          style={{ gridArea: 'map', height: '100%', display: 'flex', flexDirection: 'column' }}
-          interactive
-          elevation={Elevation.TWO}
-        >
+        <Card className={s.card} interactive elevation={Elevation.TWO}>
           <Callout intent={Intent.PRIMARY}>{t('explore.mapHint')}</Callout>
-          <div
-            style={{
-              width: '100%',
-              position: 'relative',
-              overflow: 'hidden',
-              height: '100%'
-            }}
-          >
+          <div className={s.cardBody}>
             <Map observations={filteredObservations} onInspect={setInspectedObservations} />
             <ObservationsInspector
               observations={inspectedObservations}

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -224,7 +224,6 @@ export default function ExplorePage() {
           onDarwinCoreExportClick={handleDarwinCoreExport}
           onPhotosExportClick={handlePhotosExport}
         />
-        <Divider />
         <ExplorerFilter observations={observations} updateFilters={handleFilters} />
         <ExplorerMetrics
           data={filteredObservations}

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -231,7 +231,7 @@ export default function ExplorePage() {
           overridesTotal={overridesCount(filteredObservations)}
           eventsTotal={eventsCount(filteredObservations)}
         />
-        <Card className={s.card} interactive elevation={Elevation.TWO}>
+        <Card className={s.card} elevation={Elevation.TWO}>
           <Callout intent={Intent.PRIMARY}>{t('explore.mapHint')}</Callout>
           <div className={s.cardBody}>
             <Map observations={filteredObservations} onInspect={setInspectedObservations} />

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -9,7 +9,6 @@ import {
   Intent,
   Callout,
   NumberRange,
-  Divider,
   Tooltip,
   Icon
 } from '@blueprintjs/core';

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -232,13 +232,18 @@ export default function ExplorePage() {
           overridesTotal={overridesCount(filteredObservations)}
           eventsTotal={eventsCount(filteredObservations)}
         />
-        <Card style={{ gridArea: 'map', height: '100%' }} interactive elevation={Elevation.TWO}>
+        <Card
+          style={{ gridArea: 'map', height: '100%', display: 'flex', flexDirection: 'column' }}
+          interactive
+          elevation={Elevation.TWO}
+        >
           <Callout intent={Intent.PRIMARY}>{t('explore.mapHint')}</Callout>
           <div
             style={{
               width: '100%',
               position: 'relative',
-              overflow: 'hidden'
+              overflow: 'hidden',
+              height: '100%'
             }}
           >
             <Map observations={filteredObservations} onInspect={setInspectedObservations} />

--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -215,17 +215,7 @@ export default function ExplorePage() {
     };
 
     return (
-      <div
-        style={{
-          padding: '30px 30px',
-          width: '100%',
-          overflowY: 'scroll',
-          maxHeight: 'calc(100vh - 50px)',
-          display: 'flex',
-          flexDirection: 'column',
-          position: 'relative'
-        }}
-      >
+      <div className={s.containerLoaded}>
         <ExploreHeader
           filePath={filePath}
           onDataImportClick={() => setObservations(undefined)}


### PR DESCRIPTION
Closes #221 

### Description
- updated Explorer View's layout based on the [mockup](https://github.com/Appsilon/mbaza/issues/221#issuecomment-1180357286)
- added minor improvements to metrics and map styling
- maps resizes verticaly and horizontally and has more space in the dashboard
- added scss modules instead of inline styling where it was reasonable to do so

### Note
- scss/css should be imported as `styles`. Sometimes they are imported as `s` which introduce some inconsistency
- `explorerMetrics` and `explorerFilters` components should be renamed to `PascalCase`, to keep the naming methodology consistent
- Explorer Header component was finally moved back to the top, but it wasn't updated in the quick mockup

### How to test
- interacting with the app's layout
- check code quality
