### PR TITLE
Use `react-virtuoso` for virtualization

### DIFF
--- a/app/components/ObservationsInspector.tsx
+++ b/app/components/ObservationsInspector.tsx
@@ -3,8 +3,7 @@ import { Card, Classes, Drawer, Elevation, Position, Tooltip } from '@blueprintj
 import { useTranslation } from 'react-i18next';
 import path from 'path';
 import CreatableSelect from 'react-select/creatable';
-import { FixedSizeList } from 'react-window';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import { Virtuoso } from 'react-virtuoso';
 
 import { formatAnimalClassName } from '../constants/animalsClasses';
 import { taxonOptions } from '../constants/taxons';
@@ -86,31 +85,33 @@ function ObservationCard(props: ObservationCardProps) {
   );
 
   return (
-    <Card className={styles.card} elevation={Elevation.TWO} key={observation.location}>
-      <h3 className={styles.heading}>
-        {t('explore.inspect.photoHeader', {
-          species: formatAnimalClassName(
-            predictionOverride ? predictionOverride.value : observation.pred_1
-          ),
-          date: observation.date
-        })}
-      </h3>
-      <div className={styles.body}>
-        <div className={styles.photo}>
-          <img
-            className={styles.img}
-            src={observation.location}
-            width={360}
-            alt={observation.pred_1}
-          />
+    <div className={styles.observation}>
+      <Card className={styles.card} elevation={Elevation.TWO} key={observation.location}>
+        <h3 className={styles.heading}>
+          {t('explore.inspect.photoHeader', {
+            species: formatAnimalClassName(
+              predictionOverride ? predictionOverride.value : observation.pred_1
+            ),
+            date: observation.date
+          })}
+        </h3>
+        <div className={styles.body}>
+          <div className={styles.photo}>
+            <img
+              className={styles.img}
+              src={observation.location}
+              width={360}
+              alt={observation.pred_1}
+            />
+          </div>
+          <div className={styles.data}>
+            {predictionsTable}
+            {predictionOverrideWidget}
+            {photoDetails}
+          </div>
         </div>
-        <div className={styles.data}>
-          {predictionsTable}
-          {predictionOverrideWidget}
-          {photoDetails}
-        </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }
 
@@ -119,31 +120,6 @@ type ObservationsInspectorProps = {
   onClose: () => void;
   predictionOverrides: PredictionOverridesMap;
   onPredictionOverride: PredictionOverrideHandler;
-};
-
-type ObservationRowProps = {
-  index: number;
-  style: React.CSSProperties;
-  data: {
-    observations: Observation[];
-    predictionOverrides: PredictionOverridesMap;
-    onPredictionOverride: PredictionOverrideHandler;
-  };
-};
-
-const ObservationRow = ({ index, style, data }: ObservationRowProps) => {
-  const { observations, predictionOverrides, onPredictionOverride } = data;
-  const observation = observations[index];
-  return (
-    <div style={style} className={styles.observation}>
-      <ObservationCard
-        key={observation.location}
-        observation={observation}
-        predictionOverride={predictionOverrides[observation.location]}
-        onPredictionOverride={onPredictionOverride}
-      />
-    </div>
-  );
 };
 
 export default function ObservationsInspector(props: ObservationsInspectorProps) {
@@ -167,24 +143,17 @@ export default function ObservationsInspector(props: ObservationsInspectorProps)
     >
       <div className={`${Classes.DRAWER_BODY} ${styles.drawerBody}`}>
         <div className={`${Classes.DIALOG_BODY} ${styles.dialogBody}`}>
-          <AutoSizer>
-            {({ height, width }) => (
-              <FixedSizeList
-                className={styles.list}
-                height={height}
-                itemCount={observations.length}
-                itemData={{
-                  observations,
-                  predictionOverrides,
-                  onPredictionOverride
-                }}
-                itemSize={380}
-                width={width}
-              >
-                {ObservationRow}
-              </FixedSizeList>
+          <Virtuoso
+            className={styles.list}
+            data={observations}
+            itemContent={(_index, observation) => (
+              <ObservationCard
+                observation={observation}
+                predictionOverride={predictionOverrides[observation.location]}
+                onPredictionOverride={onPredictionOverride}
+              />
             )}
-          </AutoSizer>
+          />
         </div>
       </div>
       <div className={Classes.DRAWER_FOOTER}>

--- a/package.json
+++ b/package.json
@@ -212,8 +212,6 @@
     "@types/react-dom": "^16.9.5",
     "@types/react-router-dom": "^5.1.3",
     "@types/react-test-renderer": "^16.9.2",
-    "@types/react-virtualized-auto-sizer": "^1.0.1",
-    "@types/react-window": "^1.8.5",
     "@types/sinon": "^7.5.2",
     "@types/tapable": "^1.0.5",
     "@types/universal-analytics": "^0.4.5",
@@ -312,8 +310,7 @@
     "react-i18next": "^11.17.4",
     "react-router-dom": "^5.1.2",
     "react-select": "^5.4.0",
-    "react-virtualized-auto-sizer": "^1.0.6",
-    "react-window": "^1.8.7",
+    "react-virtuoso": "^2.16.6",
     "source-map-support": "^0.5.16",
     "universal-analytics": "^0.5.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,17 +1094,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
-  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1930,20 +1930,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-virtualized-auto-sizer@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz#b3187dae1dfc4c15880c9cfc5b45f2719ea6ebd4"
-  integrity sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-window@^1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
-  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react@*", "@types/react@^16.9.17":
   version "16.9.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
@@ -2092,6 +2078,18 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@virtuoso.dev/react-urx@^0.2.12":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/react-urx/-/react-urx-0.2.13.tgz#e2cfc42d259d2a002695e7517d34cb97b64ee9c4"
+  integrity sha512-MY0ugBDjFb5Xt8v2HY7MKcRGqw/3gTpMlLXId2EwQvYJoC8sP7nnXjAxcBtTB50KTZhO0SbzsFimaZ7pSdApwA==
+  dependencies:
+    "@virtuoso.dev/urx" "^0.2.13"
+
+"@virtuoso.dev/urx@^0.2.12", "@virtuoso.dev/urx@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@virtuoso.dev/urx/-/urx-0.2.13.tgz#a65e7e8d923cb03397ac876bfdd45c7f71c8edf1"
+  integrity sha512-iirJNv92A1ZWxoOHHDYW/1KPoi83939o83iUBQHIim0i3tMeSKEh+bxhJdTHQ86Mr4uXx9xGUTq69cp52ZP8Xw==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -10090,11 +10088,6 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-"memoize-one@>=3.1.1 <6":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 memoize-one@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
@@ -12512,18 +12505,13 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized-auto-sizer@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz#66c5b1c9278064c5ef1699ed40a29c11518f97ca"
-  integrity sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==
-
-react-window@^1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.7.tgz#5e9fd0d23f48f432d7022cdb327219353a15f0d4"
-  integrity sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==
+react-virtuoso@^2.16.6:
+  version "2.16.6"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.16.6.tgz#61533bf7428e446a0586acbcffe540dd8e19a5a3"
+  integrity sha512-xpm/edDfrX2auYjnTmzdzpyxppsIvkEWtBgy1In/qMmJHMuXwhTSszCX2zsUs5SbwNCiEAbXjV7Qg1iXVa/QsA==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
+    "@virtuoso.dev/react-urx" "^0.2.12"
+    "@virtuoso.dev/urx" "^0.2.12"
 
 react@^16.13.0:
   version "16.13.1"


### PR DESCRIPTION
### Description
The solution implemented in #291 works well, but it depends on `react-virtualized-auto-sizer` which does not work with React 18 and thus blocks #241. This PR introduces `react-virtuoso` instead, which seems well-maintained and simplifies the code a bit too.

### How to test
Run the app and load a large data set. See if the observations inspector works smoothly; check out the developer tools to verify that the list is virtualized.