### PR TITLE
bugfix: Prediction override reset

### DIFF
--- a/src/renderer/components/observationsHelpers.tsx
+++ b/src/renderer/components/observationsHelpers.tsx
@@ -88,9 +88,7 @@ export function OverrideWidget({
   const predictionOverrideValue = predictionOverrides[observation.location];
   const topPrediction = getTopPrediction(observation);
   const handlePredictionOverride = (newPrediction: CreatableOption | null) => {
-    if (newPrediction === null || newPrediction.value !== topPrediction.value) {
-      onPredictionOverride([observation.location], newPrediction);
-    }
+    onPredictionOverride([observation.location], newPrediction);
   };
   return (
     <CreatableSelect


### PR DESCRIPTION
### Changes
Closes #314 

### Description
* Enabled prediction override reset

### How to test
* Change the prediction in the observation card select dropdown.
* Reset the prediction from the select dropdown.