### PR TITLE
Ftr/default language

### DIFF
--- a/src/renderer/containers/App.tsx
+++ b/src/renderer/containers/App.tsx
@@ -18,7 +18,7 @@ export default function App(props: Props) {
 
   useEffect(() => {
     i18n.changeLanguage('en');
-  });
+  }, [i18n]);
 
   return (
     <>

--- a/src/renderer/containers/App.tsx
+++ b/src/renderer/containers/App.tsx
@@ -1,5 +1,5 @@
 import { Alignment, Button, Menu, MenuItem, Navbar, Popover } from '@blueprintjs/core';
-import { useEffect, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Sidebar from '../components/Sidebar';
@@ -15,10 +15,6 @@ export default function App(props: Props) {
   const { children } = props;
   const { t, i18n } = useTranslation();
   useAnalytics();
-
-  useEffect(() => {
-    i18n.changeLanguage('en');
-  }, [i18n]);
 
   return (
     <>

--- a/src/renderer/containers/App.tsx
+++ b/src/renderer/containers/App.tsx
@@ -1,5 +1,5 @@
 import { Alignment, Button, Menu, MenuItem, Navbar, Popover } from '@blueprintjs/core';
-import { ReactNode } from 'react';
+import { useEffect, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Sidebar from '../components/Sidebar';
@@ -15,6 +15,10 @@ export default function App(props: Props) {
   const { children } = props;
   const { t, i18n } = useTranslation();
   useAnalytics();
+
+  useEffect(() => {
+    i18n.changeLanguage('en');
+  });
 
   return (
     <>

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -10,7 +10,7 @@ i18next
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
     resources: translations,
-    lng: 'fr',
+    lng: 'en',
     interpolation: {
       escapeValue: false, // react already safes from xss
     },


### PR DESCRIPTION
## Change Mbaza App's Default Language to English

### Changes
* imported `useEffect` from react
* used `useEffect` hook to trigger the `i18n.changeLanguage('en')` call when the component mounts


### How to test
* pull this branch
* package and run the app on local
* All text should appear in English by default
* user should be also able to switch to Francias