### PR TITLE
Bump version & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ to classify camera trap animal images and analyze the results.
 
 ### Installation
 
-Download Mbaza installer for your system:
-* [Windows](https://github.com/Appsilon/mbaza/releases/download/v2.1.0/Mbaza.AI.Setup.2.1.0.exe)
-* [macOS x86-64 (Intel)](https://github.com/Appsilon/mbaza/releases/download/v2.1.0/Mbaza.AI-2.1.0-mac.zip)
-* [macOS ARM64 (Apple M1)](https://github.com/Appsilon/mbaza/releases/download/v2.1.0/Mbaza.AI-2.1.0-arm64-mac.zip)
-* [Linux](https://github.com/Appsilon/mbaza/releases/download/v2.1.0/Mbaza.AI-2.1.0.AppImage)
+Visit the [latest release page](https://github.com/Appsilon/mbaza/releases/latest)
+and download Mbaza installer for your system
+(`X.Y.Z` will be the version number, e.g. `2.0.0`):
+* Windows: `Mbaza.AI.Setup.X.Y.Z.exe`
+* Linux: `Mbaza.AI-X.Y.Z.AppImage`
+* macOS:
+    * :warning: Mbaza requires additional setup to run on macOS. Read the instructions below.
+    * x86-64 (Intel): `Mbaza.AI-X.Y.Z-mac.zip`
+    * ARM64 (Apple M1): `Mbaza.AI-X.Y.Z-arm64-mac.zip`
 
 ### macOS
 

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mbaza",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mbaza",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mbaza",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "AGPL-3.0-or-later",
   "author": {
     "name": "Appsilon",


### PR DESCRIPTION
### Changes

1. Bump version to 2.1.1.
2. Update the "Installation" section in the README. Use a link to the *latest* release instead of linking directly to specific installers, so we won't need to update these links after each release.
